### PR TITLE
refactor: avoid using the elf module for performance reasons

### DIFF
--- a/yara/virus/Linux.Virus.Vit.yara
+++ b/yara/virus/Linux.Virus.Vit.yara
@@ -1,5 +1,3 @@
-import "elf"
-
 rule Linux_Virus_Vit : tc_detection malicious
 {
     meta:
@@ -32,5 +30,5 @@ rule Linux_Virus_Vit : tc_detection malicious
       $vit_str = "vi324.tmp"
 
     condition:
-        uint32(0) == 0x464C457F and $vit_entry_point at elf.entry_point and $vit_str
+        uint32(0) == 0x464C457F and all of them
 }


### PR DESCRIPTION
Hi,

importing a module is associated with costs as the information is parsed for any file scanned. Using this rule in a rule set which does not yet use the elf module therefore increases the run time significantly. We also think that using the module is not needed as using the strings without pinning them to the entry point is specific enough.

What do you think?